### PR TITLE
Remove unused RateLimitConfig import in test_security.py

### DIFF
--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -7,7 +7,7 @@ import time
 from unittest.mock import Mock, patch
 
 from no_hallucination_rag.security.security_manager import (
-    SecurityManager, RateLimiter, RateLimitConfig
+    SecurityManager, RateLimiter
 )
 from no_hallucination_rag.core.validation import InputValidator, ValidationResult
 


### PR DESCRIPTION
## Summary
- Cleans up the import statements in `tests/test_security.py` by removing the unused `RateLimitConfig` import from `no_hallucination_rag.security.security_manager`.

## Changes

### Code Cleanup
- Removed `RateLimitConfig` from the import list in `tests/test_security.py` since it is not used in the test file.

## Test plan
- Ensure existing tests in `tests/test_security.py` run successfully without import errors.
- No functional changes expected, so no additional tests required.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/0a2ef2dd-1c08-4012-9941-9251c682931b

## Summary by Sourcery

Enhancements:
- Remove unused RateLimitConfig import in tests/test_security.py for code cleanup.